### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
 
       #- uses: actions/checkout@v3
 #      - name: Publish to Registry
-#        uses: elgohr/Publish-Docker-Github-Action@v4
+#        uses: elgohr/Publish-Docker-Github-Action@v5
 #        with:
 #          name: worldbosskafka
 #          username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore